### PR TITLE
chore(jenkins): Updates Jenkins plugins

### DIFF
--- a/dockerfiles/plugins.txt
+++ b/dockerfiles/plugins.txt
@@ -7,12 +7,12 @@ branch-api:2.1200.v4b_a_3da_2eb_db_4
 build-timeout:1.33
 caffeine-api:3.1.8-133.v17b_1ff2e0599
 checks-api:2.2.1
-cloudbees-folder:6.963.v6edc0fc71472
+cloudbees-folder:6.971.v9a_984fd08864
 commons-lang3-api:3.17.0-84.vb_b_938040b_078
 commons-text-api:1.12.0-129.v99a_50df237f7
 configuration-as-code:1903.v004d55388f30
 credentials-binding:687.v619cb_15e923f
-credentials:1389.vd7a_b_f5fa_50a_2
+credentials:1393.v6017143c1763
 display-url-api:2.209.v582ed814ff2f
 durable-task:581.v299a_5609d767
 echarts-api:5.5.1-4
@@ -39,8 +39,8 @@ mailer:489.vd4b_25144138f
 matrix-auth:3.2.3
 matrix-project:840.v812f627cb_578
 metrics:4.2.21-458.vcf496cb_839e4
-mina-sshd-api-common:2.14.0-133.vcc091215a_358
-mina-sshd-api-core:2.14.0-133.vcc091215a_358
+mina-sshd-api-common:2.14.0-136.v4d2b_0853615e
+mina-sshd-api-core:2.14.0-136.v4d2b_0853615e
 okhttp-api:4.11.0-181.v1de5b_83857df
 pipeline-build-step:540.vb_e8849e1a_b_d8
 pipeline-graph-analysis:216.vfd8b_ece330ca_


### PR DESCRIPTION
This pull request updates the Jenkins plugins listed in `plugins.txt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated versions of several plugins to ensure compatibility and enhanced functionality.
		- `cloudbees-folder` upgraded to version `6.971`.
		- `credentials` upgraded to version `1393`.
		- `mina-sshd-api-common` upgraded to version `2.14.0-136`.
		- `mina-sshd-api-core` upgraded to version `2.14.0-136`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->