### PR TITLE
chore(jenkins): Updates Jenkins plugins

### DIFF
--- a/dockerfiles/plugins.txt
+++ b/dockerfiles/plugins.txt
@@ -12,7 +12,7 @@ commons-lang3-api:3.17.0-84.vb_b_938040b_078
 commons-text-api:1.12.0-129.v99a_50df237f7
 configuration-as-code:1903.v004d55388f30
 credentials-binding:687.v619cb_15e923f
-credentials:1393.v6017143c1763
+credentials:1405.vb_cda_74a_f8974
 display-url-api:2.209.v582ed814ff2f
 durable-task:581.v299a_5609d767
 echarts-api:5.5.1-4
@@ -41,7 +41,7 @@ matrix-project:840.v812f627cb_578
 metrics:4.2.21-458.vcf496cb_839e4
 mina-sshd-api-common:2.14.0-136.v4d2b_0853615e
 mina-sshd-api-core:2.14.0-136.v4d2b_0853615e
-okhttp-api:4.11.0-181.v1de5b_83857df
+okhttp-api:4.11.0-183.va_87fc7a_89810
 pipeline-build-step:540.vb_e8849e1a_b_d8
 pipeline-graph-analysis:216.vfd8b_ece330ca_
 pipeline-graph-view:382.vb_9a_27b_7b_ea_71
@@ -72,7 +72,7 @@ variant:60.v7290fc0eb_b_cd
 workflow-aggregator:600.vb_57cdd26fdd7
 workflow-api:1336.vee415d95c521
 workflow-basic-steps:1058.vcb_fc1e3a_21a_9
-workflow-cps:4000.v5198556e9cea_
+workflow-cps:4002.v80ca_d0f47d7f
 workflow-durable-task-step:1398.vf6c9e89e5988
 workflow-job:1472.ve4d5eca_143c4
 workflow-multibranch:795.ve0cb_1f45ca_9a_


### PR DESCRIPTION
This pull request updates the Jenkins plugins listed in `plugins.txt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated version numbers for various plugins, including `credentials`, `okhttp-api`, and `workflow-cps`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->