### PR TITLE
chore(jenkins): Updates Jenkins plugins

### DIFF
--- a/dockerfiles/plugins.txt
+++ b/dockerfiles/plugins.txt
@@ -10,9 +10,9 @@ checks-api:2.2.1
 cloudbees-folder:6.975.v4161e479479f
 commons-lang3-api:3.17.0-84.vb_b_938040b_078
 commons-text-api:1.12.0-129.v99a_50df237f7
-configuration-as-code:1903.v004d55388f30
+configuration-as-code:1909.vb_b_f59a_27d013
 credentials-binding:687.v619cb_15e923f
-credentials:1393.v6017143c1763
+credentials:1405.vb_cda_74a_f8974
 display-url-api:2.209.v582ed814ff2f
 durable-task:581.v299a_5609d767
 echarts-api:5.5.1-4
@@ -41,7 +41,7 @@ matrix-project:840.v812f627cb_578
 metrics:4.2.21-458.vcf496cb_839e4
 mina-sshd-api-common:2.14.0-136.v4d2b_0853615e
 mina-sshd-api-core:2.14.0-136.v4d2b_0853615e
-okhttp-api:4.11.0-181.v1de5b_83857df
+okhttp-api:4.11.0-183.va_87fc7a_89810
 pipeline-build-step:540.vb_e8849e1a_b_d8
 pipeline-graph-analysis:216.vfd8b_ece330ca_
 pipeline-graph-view:382.vb_9a_27b_7b_ea_71
@@ -62,7 +62,7 @@ scm-api:698.v8e3b_c788f0a_6
 script-security:1369.v9b_98a_4e95b_2d
 snakeyaml-api:2.3-123.v13484c65210a_
 ssh-credentials:349.vb_8b_6b_9709f5b_
-ssh-slaves:2.1010.v64ec48721231
+ssh-slaves:3.1021.va_cc11b_de26a_e
 sshd:3.330.vc866a_8389b_58
 structs:338.v848422169819
 timestamper:1.28
@@ -72,7 +72,7 @@ variant:60.v7290fc0eb_b_cd
 workflow-aggregator:600.vb_57cdd26fdd7
 workflow-api:1336.vee415d95c521
 workflow-basic-steps:1058.vcb_fc1e3a_21a_9
-workflow-cps:4000.v5198556e9cea_
+workflow-cps:4002.v80ca_d0f47d7f
 workflow-durable-task-step:1398.vf6c9e89e5988
 workflow-job:1472.ve4d5eca_143c4
 workflow-multibranch:795.ve0cb_1f45ca_9a_


### PR DESCRIPTION
This pull request updates the Jenkins plugins listed in `plugins.txt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated several plugin versions to enhance functionality and performance.
		- `configuration-as-code` plugin upgraded to version `1909`.
		- `credentials` plugin upgraded to version `1405`.
		- `okhttp-api` plugin upgraded to version `4.11.0-183`.
		- `ssh-slaves` plugin upgraded to version `3.1021`.
		- `workflow-cps` plugin upgraded to version `4002`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->