### PR TITLE
chore(jenkins): Updates Jenkins plugins

### DIFF
--- a/dockerfiles/plugins.txt
+++ b/dockerfiles/plugins.txt
@@ -15,7 +15,7 @@ credentials-binding:687.v619cb_15e923f
 credentials:1405.vb_cda_74a_f8974
 display-url-api:2.209.v582ed814ff2f
 durable-task:581.v299a_5609d767
-echarts-api:5.5.1-4
+echarts-api:5.5.1-5
 font-awesome-api:6.6.0-2
 git-client:6.1.0
 git:5.6.0
@@ -39,8 +39,8 @@ mailer:489.vd4b_25144138f
 matrix-auth:3.2.3
 matrix-project:840.v812f627cb_578
 metrics:4.2.21-458.vcf496cb_839e4
-mina-sshd-api-common:2.14.0-136.v4d2b_0853615e
-mina-sshd-api-core:2.14.0-136.v4d2b_0853615e
+mina-sshd-api-common:2.14.0-138.v6341ee58e1df
+mina-sshd-api-core:2.14.0-138.v6341ee58e1df
 okhttp-api:4.11.0-183.va_87fc7a_89810
 pipeline-build-step:540.vb_e8849e1a_b_d8
 pipeline-graph-analysis:216.vfd8b_ece330ca_


### PR DESCRIPTION
This pull request updates the Jenkins plugins listed in `plugins.txt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated plugin versions:
		- `echarts-api` from `5.5.1-4` to `5.5.1-5`
		- `mina-sshd-api-common` from `2.14.0-136` to `2.14.0-138`
		- `mina-sshd-api-core` from `2.14.0-136` to `2.14.0-138`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->