### PR TITLE
chore(jenkins): Updates Jenkins plugins

### DIFF
--- a/dockerfiles/plugins.txt
+++ b/dockerfiles/plugins.txt
@@ -18,7 +18,7 @@ durable-task:581.v299a_5609d767
 echarts-api:5.5.1-5
 font-awesome-api:6.6.0-2
 git-client:6.1.0
-git:5.6.0
+git:5.7.0
 github-api:1.321-478.vc9ce627ce001
 github-branch-source:1807.v50351eb_7dd13
 github:1.40.0
@@ -45,7 +45,7 @@ okhttp-api:4.11.0-183.va_87fc7a_89810
 pipeline-build-step:540.vb_e8849e1a_b_d8
 pipeline-graph-analysis:216.vfd8b_ece330ca_
 pipeline-graph-view:382.vb_9a_27b_7b_ea_71
-pipeline-groovy-lib:744.v5b_556ee7c253
+pipeline-groovy-lib:745.vdf6077913de0
 pipeline-input-step:495.ve9c153f6067b_
 pipeline-milestone-step:119.vdfdc43fc3b_9a_
 pipeline-model-api:2.2218.v56d0cda_37c72


### PR DESCRIPTION
This pull request updates the Jenkins plugins listed in `plugins.txt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `git` plugin to version 5.7.0
	- Updated `pipeline-groovy-lib` plugin to version 745

<!-- end of auto-generated comment: release notes by coderabbit.ai -->