### PR TITLE
chore(jenkins): Updates Jenkins plugins

### DIFF
--- a/dockerfiles/plugins.txt
+++ b/dockerfiles/plugins.txt
@@ -73,7 +73,7 @@ workflow-aggregator:600.vb_57cdd26fdd7
 workflow-api:1336.vee415d95c521
 workflow-basic-steps:1058.vcb_fc1e3a_21a_9
 workflow-cps:4007.vd705fc76a_34e
-workflow-durable-task-step:1398.vf6c9e89e5988
+workflow-durable-task-step:1400.v7a_fd50a_091de
 workflow-job:1476.v90f02a_225559
 workflow-multibranch:795.ve0cb_1f45ca_9a_
 workflow-scm-step:427.v4ca_6512e7df1


### PR DESCRIPTION
This pull request updates the Jenkins plugins listed in `plugins.txt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `workflow-durable-task-step` plugin to a newer version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->