### PR TITLE
chore(jenkins): Updates Jenkins plugins

### DIFF
--- a/dockerfiles/plugins.txt
+++ b/dockerfiles/plugins.txt
@@ -3,7 +3,7 @@ antisamy-markup-formatter:162.v0e6ec0fcfcf6
 apache-httpcomponents-client-4-api:4.5.14-208.v438351942757
 bootstrap5-api:5.3.3-1
 bouncycastle-api:2.30.1.79-254.vfdb_814e7791e
-branch-api:2.1206.vd9f35001c95c
+branch-api:2.1208.vf528356feca_4
 build-timeout:1.33
 caffeine-api:3.1.8-133.v17b_1ff2e0599
 checks-api:2.2.1
@@ -20,7 +20,7 @@ font-awesome-api:6.6.0-2
 git-client:6.1.0
 git:5.7.0
 github-api:1.321-478.vc9ce627ce001
-github-branch-source:1807.v50351eb_7dd13
+github-branch-source:1809.v088b_5f22c768
 github:1.40.0
 gradle:2.14
 instance-identity:201.vd2a_b_5a_468a_a_6
@@ -44,8 +44,8 @@ mina-sshd-api-core:2.14.0-138.v6341ee58e1df
 okhttp-api:4.11.0-183.va_87fc7a_89810
 pipeline-build-step:540.vb_e8849e1a_b_d8
 pipeline-graph-analysis:216.vfd8b_ece330ca_
-pipeline-graph-view:382.vb_9a_27b_7b_ea_71
-pipeline-groovy-lib:745.vdf6077913de0
+pipeline-graph-view:401.v99b_6582132f4
+pipeline-groovy-lib:749.v70084559234a_
 pipeline-input-step:508.v584c0e9a_2177
 pipeline-milestone-step:119.vdfdc43fc3b_9a_
 pipeline-model-api:2.2218.v56d0cda_37c72
@@ -70,13 +70,13 @@ token-macro:400.v35420b_922dcb_
 trilead-api:2.147.vb_73cc728a_32e
 variant:60.v7290fc0eb_b_cd
 workflow-aggregator:600.vb_57cdd26fdd7
-workflow-api:1336.vee415d95c521
+workflow-api:1358.vfb_5780da_64cb_
 workflow-basic-steps:1058.vcb_fc1e3a_21a_9
 workflow-cps:4007.vd705fc76a_34e
-workflow-durable-task-step:1398.vf6c9e89e5988
-workflow-job:1476.v90f02a_225559
+workflow-durable-task-step:1400.v7a_fd50a_091de
+workflow-job:1496.v5b_18defc07f2
 workflow-multibranch:795.ve0cb_1f45ca_9a_
 workflow-scm-step:427.v4ca_6512e7df1
 workflow-step-api:678.v3ee58b_469476
-workflow-support:936.v9fa_77211ca_e1
+workflow-support:943.v8b_0d01a_7b_a_08
 ws-cleanup:0.48


### PR DESCRIPTION
This pull request updates the Jenkins plugins listed in `plugins.txt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated plugin versions for multiple Jenkins-related plugins, including:
		- branch-api
		- github-branch-source
		- pipeline-graph-view
		- pipeline-groovy-lib
		- workflow-api
		- workflow-durable-task-step
		- workflow-job
		- workflow-support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->