### PR TITLE
chore(jenkins): Updates Jenkins plugins

### DIFF
--- a/dockerfiles/plugins.txt
+++ b/dockerfiles/plugins.txt
@@ -4,7 +4,7 @@ apache-httpcomponents-client-4-api:4.5.14-208.v438351942757
 bootstrap5-api:5.3.3-1
 bouncycastle-api:2.30.1.80-256.vf98926042a_9b_
 branch-api:2.1208.vf528356feca_4
-build-timeout:1.33
+build-timeout:1.35
 caffeine-api:3.1.8-133.v17b_1ff2e0599
 checks-api:2.2.1
 cloudbees-folder:6.980.v5a_cc0cb_25881


### PR DESCRIPTION
This pull request updates the Jenkins plugins listed in `plugins.txt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build-timeout plugin to version 1.35

<!-- end of auto-generated comment: release notes by coderabbit.ai -->