### PR TITLE
chore(jenkins): Updates Jenkins plugins

### DIFF
--- a/dockerfiles/plugins.txt
+++ b/dockerfiles/plugins.txt
@@ -4,7 +4,7 @@ apache-httpcomponents-client-4-api:4.5.14-208.v438351942757
 bootstrap5-api:5.3.3-1
 bouncycastle-api:2.30.1.80-256.vf98926042a_9b_
 branch-api:2.1208.vf528356feca_4
-build-timeout:1.33
+build-timeout:1.35
 caffeine-api:3.1.8-133.v17b_1ff2e0599
 checks-api:2.2.1
 cloudbees-folder:6.980.v5a_cc0cb_25881
@@ -20,7 +20,7 @@ font-awesome-api:6.6.0-2
 git-client:6.1.1
 git:5.7.0
 github-api:1.321-478.vc9ce627ce001
-github-branch-source:1809.v088b_5f22c768
+github-branch-source:1810.v913311241fa_9
 github:1.40.0
 gradle:2.14
 instance-identity:201.vd2a_b_5a_468a_a_6
@@ -77,6 +77,6 @@ workflow-durable-task-step:1400.v7a_fd50a_091de
 workflow-job:1498.v33a_0c6f3a_4b_4
 workflow-multibranch:795.ve0cb_1f45ca_9a_
 workflow-scm-step:427.v4ca_6512e7df1
-workflow-step-api:678.v3ee58b_469476
-workflow-support:943.v8b_0d01a_7b_a_08
+workflow-step-api:683.va_885a_76415f9
+workflow-support:944.v5a_859593b_98a_
 ws-cleanup:0.48


### PR DESCRIPTION
This pull request updates the Jenkins plugins listed in `plugins.txt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated plugin versions:
		- `build-timeout` to version 1.35
		- `github-branch-source` to version 1810
		- `workflow-step-api` to version 683
		- `workflow-support` to version 944

<!-- end of auto-generated comment: release notes by coderabbit.ai -->